### PR TITLE
Nova 2.0 foreign key name error

### DIFF
--- a/src/NovaBelongstoDepends.php
+++ b/src/NovaBelongstoDepends.php
@@ -73,10 +73,10 @@ class NovaBelongsToDepends extends BelongsTo
         $this->resourceParentClass = get_class(Nova::newResourceFromModel($resource));
 
         $foreign = $resource->{$this->attribute}();
-        $this->foreignKeyName = $foreign->getForeignKey();
+        $this->foreignKeyName = $this->getRelationForeignKeyName($foreign);
 
         if ($this->dependsOn) {
-            $this->dependKey = $resource->{$this->dependsOn}()->getForeignKey();
+            $this->dependKey = $this->getRelationForeignKeyName($resource->{$this->dependsOn}());
         }
 
         $value = $resource->{$this->attribute}()->withoutGlobalScopes()->first();


### PR DESCRIPTION
In Nova 2.0 getForeignKey => getForeignKeyName. This change make this package stop working.
To support both a new function was added getRelationForeignKeyName() which is implemented with this fix.